### PR TITLE
Populate id field

### DIFF
--- a/generator/src/main/java/de/westnordost/countryboundaries/GeoJsonWriter.java
+++ b/generator/src/main/java/de/westnordost/countryboundaries/GeoJsonWriter.java
@@ -20,6 +20,7 @@ public class GeoJsonWriter
 {
 	private static final String
 			TYPE = "type",
+			ID = "id",
 			FEATURES = "features",
 			COORDINATES = "coordinates",
 			GEOMETRIES = "geometries",
@@ -69,6 +70,14 @@ public class GeoJsonWriter
 	{
 		b.object();
 		b.key(TYPE).value("Feature");
+		if (g.getUserData() instanceof Map<?,?> && ((Map<?,?>) g.getUserData()).containsKey(ID))
+		{
+			Object id = ((Map<?, ?>) g.getUserData()).get(ID);
+			if (id instanceof String || id instanceof Number)
+			{
+				b.key(ID).value(id);
+			}
+		}
 		b.key(PROPERTIES);
 		writeProperties(b, g.getUserData());
 		b.key(GEOMETRY);

--- a/generator/src/test/java/de/westnordost/countryboundaries/GeoJsonWriterTest.java
+++ b/generator/src/test/java/de/westnordost/countryboundaries/GeoJsonWriterTest.java
@@ -205,6 +205,34 @@ public class GeoJsonWriterTest
 				"}]}", write(g));
 	}
 
+	@Test public void writeFeatureWithStringId()
+	{
+		Polygon g = factory.createPolygon(
+				factory.createLinearRing(new Coordinate[]{p(0,0), p(0,4), p(4,0), p(0,0)}),
+				new LinearRing[]{factory.createLinearRing(new Coordinate[] {p(1,1), p(2,1), p(1,2), p(1,1)})}
+		);
+		g.setUserData(Collections.singletonMap("id", "DE"));
+		assertEquals("{" +
+				"\"type\":\"Feature\",\"id\":\"DE\",\"properties\":{\"id\":\"DE\"}," +
+				"\"geometry\":{\"type\":\"Polygon\"," +
+				"\"coordinates\":[[[0,0],[4,0],[0,4],[0,0]],[[1,1],[1,2],[2,1],[1,1]]]}" +
+				"}", write(g));
+	}
+
+	@Test public void writeFeatureWithNumericId()
+	{
+		Polygon g = factory.createPolygon(
+				factory.createLinearRing(new Coordinate[]{p(0,0), p(0,4), p(4,0), p(0,0)}),
+				new LinearRing[]{factory.createLinearRing(new Coordinate[] {p(1,1), p(2,1), p(1,2), p(1,1)})}
+		);
+		g.setUserData(Collections.singletonMap("id", 123));
+		assertEquals("{" +
+				"\"type\":\"Feature\",\"id\":123,\"properties\":{\"id\":123}," +
+				"\"geometry\":{\"type\":\"Polygon\"," +
+				"\"coordinates\":[[[0,0],[4,0],[0,4],[0,0]],[[1,1],[1,2],[2,1],[1,1]]]}" +
+				"}", write(g));
+	}
+
 	private static String write(Geometry g)
 	{
 		return new GeoJsonWriter().write(g);


### PR DESCRIPTION
As discussed with @karussell in https://github.com/graphhopper/graphhopper/pull/3131#issuecomment-2739931381

The resulting file is valid GeoJSON as per https://datatracker.ietf.org/doc/html/rfc7946#section-3.2

> If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of the Feature object with the name"id", and the value of this member is either a JSON string or number.