### PR TITLE
Handle GeometryCollection returned by intersection method

### DIFF
--- a/generator/src/main/java/de/westnordost/countryboundaries/CountryBoundariesGenerator.java
+++ b/generator/src/main/java/de/westnordost/countryboundaries/CountryBoundariesGenerator.java
@@ -81,18 +81,7 @@ public class CountryBoundariesGenerator
 			{
 				Geometry intersection = g.intersection(bounds);
 				List<Geometry> polygons = new ArrayList<>();
-				if (intersection instanceof GeometryCollection) {
-					GeometryCollection gc = (GeometryCollection) intersection;
-					for (int i = 0; i < gc.getNumGeometries(); i++) {
-						Geometry sub = gc.getGeometryN(i);
-						if (sub instanceof Polygonal) {
-							polygons.add(sub);
-						}
-					}
-				} else if (intersection instanceof Polygonal) {
-					polygons.add(intersection);
-				}
-
+				collectPolygons(intersection, polygons);
 				for (Geometry poly : polygons) {
 					poly.normalize();
 					intersectingAreas.add(createCountryAreas(areaId, poly, lonMin, latMin, lonMax, latMax));
@@ -101,6 +90,19 @@ public class CountryBoundariesGenerator
 		}
 		return new CountryBoundariesCell(containingIds, intersectingAreas);
 	}
+
+	// Helper function to recursively collect all Polygonal geometries
+	private void collectPolygons(Geometry geom, List<Geometry> polygons) {
+		if (geom instanceof GeometryCollection) {
+			GeometryCollection gc = (GeometryCollection) geom;
+			for (int i = 0; i < gc.getNumGeometries(); i++) {
+				collectPolygons(gc.getGeometryN(i), polygons);
+			}
+		} else if (geom instanceof Polygonal) {
+			polygons.add(geom);
+		}
+	}
+
 
 	private CountryAreas createCountryAreas(
 			String areaId, Geometry intersection, double lonMin, double latMin, double lonMax, double latMax)


### PR DESCRIPTION
The `public Geometry intersection(Geometry other)` method from `com.vividsolutions.jts.geom.Geometry` can return a `com.vividsolutions.jts.geom.GeometryCollection` which is basically like a list of `com.vividsolutions.jts.geom.Geometry`. This list can contain `com.vividsolutions.jts.geom.Polygonal`.

Currently in the method `createPoints` of the class `CountryBoundariesGenerator` everything that is not a `Polygonal` is skipped.

I extended the method to go through all geometries in `GeometryCollection` intersection results as well and handle all the `Polygonal` that are stored within it.

**Why?**
I extracted the `boundary=administrative`, `admin_level=2` boundaries from OpenStreetMap planet file. They are very detailed. I noticed some points close to the US / MX border, inside the US, were not assigned to the US as expected.
I did some digging and noticed that the boundary was missing in the raster cell. Further debugging showed, that when creating the cell, the relevant part for the US border was skipped because it was stored inside a `GeometryCollection`.